### PR TITLE
Fix error with non-default base path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+index.cjs linguist-generated

--- a/index.js
+++ b/index.js
@@ -23,27 +23,48 @@ import { createHash } from 'crypto'
 import cheerio from 'cheerio'
 import fetch from 'node-fetch'
 
-export default function sri () {
+export default function sri() {
+  let config
+
   return {
     name: 'vite-plugin-sri',
     enforce: 'post',
     apply: 'build',
 
+    configResolved(resolvedConfig) {
+      config = resolvedConfig
+    },
+
     async transformIndexHtml(html, context) {
       const bundle = context.bundle
 
-      const calculateIntegrityHashes = async (element) => {
-        let source
-        let attributeName = element.attribs.src ? 'src' : 'href'
-        const resourcePath = element.attribs[attributeName]
-        if (resourcePath.startsWith('http')) {
-          // Load remote source from URL.
-          source = await (await fetch(resourcePath)).buffer()
-        } else {
+      const getResource = async(path) => {
+        const { base } = config
+        const pathWithoutBase = base.length && path.startsWith(base) ? path.slice(base.length) : path
+
+        if (pathWithoutBase in bundle) {
           // Load local source from bundle.
-          const resourcePathWithoutLeadingSlash = element.attribs[attributeName].slice(1)
-          const bundleItem = bundle[resourcePathWithoutLeadingSlash]
-          source = bundleItem.code || bundleItem.source
+          const bundleItem = bundle[pathWithoutBase]
+          return bundleItem.code ?? bundleItem.source
+        } else if (path.startsWith('http://') || path.startsWith('https://')) {
+          // Load remote source from URL.
+          const resp = await fetch(path)
+          if (!resp.ok) {
+            throw new Error(`Could not resolve resource '${path}': http ${resp.status} ${resp.statusText}`)
+          }
+          return await resp.text()
+        } else {
+          return null
+        }
+      }
+
+      const calculateIntegrityHashes = async (element) => {
+        const attributeName = element.attribs.src ? 'src' : 'href'
+        const resourcePath = element.attribs[attributeName]
+        const source = await getResource(resourcePath)
+        if (source === null) {
+          console.warn(`Could not resolve resource '${resourcePath}'`)
+          return;
         }
         element.attribs.integrity = `sha384-${createHash('sha384').update(source).digest().toString('base64')}`
       }
@@ -51,7 +72,7 @@ export default function sri () {
       const $ = cheerio.load(html)
       $.prototype.asyncForEach = async function (callback) {
         for (let index = 0; index < this.length; index++) {
-          await callback(this[index], index, this);
+          await callback(this[index], index, this)
         }
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import { readFile } from 'fs/promises'
 import path from 'path'
 import test from 'tape'
 import { fileURLToPath } from 'url'
@@ -9,26 +9,44 @@ import sri from '../index.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
+async function loadFixture(location) {
+  let source;
+  if (location.startsWith('http')) {
+    source = await (await fetch(location)).text()
+  } else {
+    source = await readFile(path.join(__dirname, 'fixtures', location), 'utf8')
+  }
+
+  const hash = createHash('sha384').update(source).digest().toString('base64')
+
+  return { source, hash }
+}
+
+async function loadLocalResources() {
+  const { source: localJS, hash: localJSHash } = await loadFixture('main.js')
+  const { source: localCSS, hash: localCSSHash } = await loadFixture(path.join('assets', 'style.css'))
+
+  return { localJS, localCSS, localJSHash, localCSSHash }
+}
+
+async function loadRemoteResources() {
+  const { source: remoteJS, hash: remoteJSHash } = await loadFixture('https://ar.al/chat.js')
+  const { source: remoteCSS, hash: remoteCSSHash } = await loadFixture('https://ar.al/style.css')
+
+  return { remoteJS, remoteCSS, remoteJSHash, remoteCSSHash }
+}
+
 test('basic functionality', async (t) => {
 
   // Setup
-  const fixtures = path.join(__dirname, 'fixtures')
+  const { source: indexHTML } = await loadFixture('index.html')
+  const { localJS, localCSS, localJSHash, localCSSHash } = await loadLocalResources()
+  const { remoteJSHash, remoteCSSHash } = await loadRemoteResources()
 
-  const indexHTML = fs.readFileSync(path.join(fixtures, 'index.html'))
-  const localJS = fs.readFileSync(path.join(fixtures, 'main.js'))
-  const localCSS = fs.readFileSync(path.join(fixtures, 'assets', 'style.css'))
-  const remoteJS = await (await fetch('https://ar.al/chat.js')).buffer()
-  const remoteCSS = await (await fetch('https://ar.al/style.css')).buffer()
-
-  const localJSHash = createHash('sha384').update(localJS).digest().toString('base64')
-  const localCSSHash = createHash('sha384').update(localCSS).digest().toString('base64')
-  const remoteJSHash = createHash('sha384').update(remoteJS).digest().toString('base64')
-  const remoteCSSHash = createHash('sha384').update(remoteCSS).digest().toString('base64')
-
-  const expectedLocalCSSLinkTag = `<link rel="stylesheet" type="text/css" href="/assets/style.css" integrity="sha384-${localCSSHash}">`
-  const expectedRemoteCSSLinkTag = `<link rel="stylesheet" type="text/css" href="https://ar.al/style.css" integrity="sha384-${remoteCSSHash}">`
   const expectedLocalJSScriptTag = `<script type="module" src="/main.js" integrity="sha384-${localJSHash}"></script>`
+  const expectedLocalCSSLinkTag = `<link rel="stylesheet" type="text/css" href="/assets/style.css" integrity="sha384-${localCSSHash}">`
   const expectedRemoteJSScriptTag = `<script type="module" src="https://ar.al/chat.js" integrity="sha384-${remoteJSHash}"></script>`
+  const expectedRemoteCSSLinkTag = `<link rel="stylesheet" type="text/css" href="https://ar.al/style.css" integrity="sha384-${remoteCSSHash}">`
 
   const context = {
     bundle: {
@@ -39,6 +57,10 @@ test('basic functionality', async (t) => {
 
   const plugin = sri()
 
+  plugin.configResolved({
+    base: '/'
+  })
+
   t.strictEquals(plugin.name, 'vite-plugin-sri', 'Plugin name is as expected.')
   t.strictEquals(plugin.apply, 'build', 'Plugin applies to build tasks only.')
   t.strictEquals(plugin.enforce, 'post', 'Plugin is enforced to run during post stage.')
@@ -47,6 +69,39 @@ test('basic functionality', async (t) => {
 
   t.true(html.includes(expectedLocalCSSLinkTag), 'Transformed HTML includes expected local CSS link tag.')
   t.true(html.includes(expectedRemoteCSSLinkTag), 'Transformed HTML includes expected remote CSS link tag.')
-  t.true(html.includes(expectedLocalJSScriptTag), 'Transformed HTML includes expected local JS link tag.')
-  t.true(html.includes(expectedRemoteJSScriptTag), 'Transformed HTML includes expected remote JS link tag.')
+  t.true(html.includes(expectedLocalJSScriptTag), 'Transformed HTML includes expected local JS script tag.')
+  t.true(html.includes(expectedRemoteJSScriptTag), 'Transformed HTML includes expected remote JS script tag.')
+})
+
+test('base path handling', async (t) => {
+
+  const { localJS, localCSS, localJSHash } = await loadLocalResources()
+
+  const context = {
+    bundle: {
+      'assets/style.css': { source: localCSS },
+      'main.js': { code: localJS }
+    }
+  }
+
+  const cases = [
+    { id: 'local',    base: '/local/',              src: `/local/main.js`,              integrity: `sha384-${localJSHash}` },
+    { id: 'empty',    base: '',                     src: `main.js`,                     integrity: `sha384-${localJSHash}` },
+    { id: 'http',     base: 'https://example.com/', src: `https://example.com/main.js`, integrity: `sha384-${localJSHash}` },
+    { id: 'external', base: '/',                    src: `../lib/nonexistent.js`,       integrity: null },
+  ]
+
+  for (const testCase of cases) {
+    const plugin = sri()
+
+    plugin.configResolved({
+      base: testCase.base
+    })
+
+    const input = `<script src="${testCase.src}"></script>`
+    const expectedTag = testCase.integrity ? `<script src="${testCase.src}" integrity="${testCase.integrity}"></script>` : input;
+    const output = await plugin.transformIndexHtml(input, context)
+
+    t.true(output.includes(expectedTag), `Correctly handles base path test case '${testCase.id}'.`)
+  }
 })


### PR DESCRIPTION
### Bug Description

Failure to build when the vite config `base` is anything but the default `/`.

### Reproduction

1. Run `npm init @vitejs/app`, any profile will do.
2. `cd` to the created project directory.
3. Run `npm i -D @small-tech/vite-plugin-sri`.
4. Add `vite.config.js`:
  ```js
import { defineConfig } from 'vite'
import sri from '@small-tech/vite-plugin-sri'

export default defineConfig({
    base: "/somewhere/",
    plugins: [sri()]
})
  ```
5. Run `npm run build`.

#### Expected behaviour

```html
  <script type="module" crossorigin="" src="/assets/index.[hash].js" integrity="sha384-[something]"></script>
  <link rel="stylesheet" href="/assets/index.[hash].css" integrity="sha384-[something]">
```

#### Actual behaviour

```
TypeError: Cannot read property 'code' of undefined
    at calculateIntegrityHashes (file:///./node_modules/@small-tech/vite-plugin-sri/index.js:46:31)
    at initialize.$.asyncForEach (file:///./node_modules/@small-tech/vite-plugin-sri/index.js:54:17)
    at transformIndexHtml (file:///./node_modules/@small-tech/vite-plugin-sri/index.js:62:21)
    at applyHtmlTransforms (.\node_modules\vite\dist\node\chunks\dep-cb562f8f.js:24645:27)
    at Object.generateBundle (.\node_modules\vite\dist\node\chunks\dep-cb562f8f.js:24605:32)
```

### Environment

* vite-plugin-sri `v1.0.1`
* vite `v2.3.6`