### PR TITLE
Provide CommonJS build

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// @small-tech/vite-plugin-sri
+//
+// Subresource integrity (SRI) plugin for Vite (https://vitejs.dev/)
+//
+// Adds subresource integrity hashes to script and stylesheet
+// imports from your index.html file at build time.
+//
+// If you’re looking for a generic Rollup plugin that does the same thing,
+// see rollup-plugin-sri by Jonas Kruckenberg that this one was inspired by:
+// https://github.com/JonasKruckenberg/rollup-plugin-sri
+//
+// Like this? Fund us!
+// https://small-tech.org/fund-us
+//
+// Copyright ⓒ 2021-present Aral Balkan, Small Technology Foundation
+// License: ISC.
+//
+////////////////////////////////////////////////////////////////////////////////
+'use strict';
+
+const crypto = require('crypto');
+const cheerio = require('cheerio');
+const fetch = require('node-fetch');
+
+////////////////////////////////////////////////////////////////////////////////
+
+function sri () {
+  return {
+    name: 'vite-plugin-sri',
+    enforce: 'post',
+    apply: 'build',
+
+    async transformIndexHtml(html, context) {
+      const bundle = context.bundle;
+
+      const calculateIntegrityHashes = async (element) => {
+        let source;
+        let attributeName = element.attribs.src ? 'src' : 'href';
+        const resourcePath = element.attribs[attributeName];
+        if (resourcePath.startsWith('http')) {
+          // Load remote source from URL.
+          source = await (await fetch(resourcePath)).buffer();
+        } else {
+          // Load local source from bundle.
+          const resourcePathWithoutLeadingSlash = element.attribs[attributeName].slice(1);
+          const bundleItem = bundle[resourcePathWithoutLeadingSlash];
+          source = bundleItem.code || bundleItem.source;
+        }
+        element.attribs.integrity = `sha384-${crypto.createHash('sha384').update(source).digest().toString('base64')}`;
+      };
+
+      const $ = cheerio.load(html);
+      $.prototype.asyncForEach = async function (callback) {
+        for (let index = 0; index < this.length; index++) {
+          await callback(this[index], index, this);
+        }
+      };
+
+      // Implement SRI for scripts and stylesheets.
+      const scripts = $('script').filter('[src]');
+      const stylesheets = $('link[rel=stylesheet]').filter('[href]');
+
+      await scripts.asyncForEach(calculateIntegrityHashes);
+      await stylesheets.asyncForEach(calculateIntegrityHashes);
+
+      return $.html()
+    }
+  }
+}
+
+module.exports = sri;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "c8": "^7.7.0",
+        "rollup": "^2.51.0",
         "tape": "^5.2.2"
       },
       "funding": {
@@ -516,6 +517,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -1185,6 +1200,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.0.tgz",
+      "integrity": "sha512-ITLt9sScNCBVspSHauw/W49lEZ0vjN8LyCzSNsNaqT67vTss2lYEfOyxltX8hjrhr1l/rQwmZ2wazzEqhZ/fUg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
       }
     },
     "node_modules/safe-buffer": {
@@ -1940,6 +1970,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2403,6 +2440,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.0.tgz",
+      "integrity": "sha512-ITLt9sScNCBVspSHauw/W49lEZ0vjN8LyCzSNsNaqT67vTss2lYEfOyxltX8hjrhr1l/rQwmZ2wazzEqhZ/fUg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.1"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,13 @@
   "version": "1.0.1",
   "description": "A Vite plugin that adds subresource integrity hashes to your index.html file at build time.",
   "type": "module",
-  "main": "index.js",
+  "main": "index.cjs",
+  "exports": {
+    "import": "./index.js",
+    "require": "./index.cjs"
+  },
   "scripts": {
+    "build": "rollup -c",
     "test": "node test/index.js",
     "coverage": "c8 node test/index.js"
   },
@@ -16,7 +21,7 @@
     "type": "git",
     "url": "git+https://github.com/small-tech/vite-plugin-sri.git"
   },
-  "files": [],
+  "files": ["index.js"],
   "keywords": [
     "Vite",
     "Subresource",
@@ -36,6 +41,7 @@
   "license": "ISC",
   "devDependencies": {
     "c8": "^7.7.0",
+    "rollup": "^2.51.0",
     "tape": "^5.2.2"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs'
+
+export default {
+  input: 'index.js',
+  output: {
+    file: 'index.cjs',
+    format: 'cjs',
+    exports: 'default',
+    preferConst: true,
+
+    // https://nodejs.org/api/esm.html#esm_commonjs_namespaces
+    interop: 'default',
+
+    // Extract license header
+    banner: () => readFileSync('index.js', 'utf8').match(/^\/{4,}[^]+?\/{4,}/)[0]
+  },
+  external: () => true
+}


### PR DESCRIPTION
Fix #1, done according to recommended practices from [Dual CommonJS/ES module packages | Node.js Documentation](https://nodejs.org/api/packages.html#packages_dual_commonjs_es_module_packages) and rollup.js docs.

---

> Setting "type":"module" on my project fixed the issue, but you should think about providing both a cjs and esm version, most people will be thrown off by this I think.

Using `type: module` often isn't a solution because it affects every dependencies you have, so even if this issue is fixed, other packages will starting to compain about various things and it's a pain to fix them all.