### PR TITLE
Fixed error with non-standard base

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -27,10 +27,15 @@ const fetch = require('node-fetch');
 ////////////////////////////////////////////////////////////////////////////////
 
 function sri () {
+  let base = "/";
   return {
     name: 'vite-plugin-sri',
     enforce: 'post',
     apply: 'build',
+
+    async configResolved(config) {
+      base = config.base === "" ? "./" : config.base;
+    },
 
     async transformIndexHtml(html, context) {
       const bundle = context.bundle;
@@ -44,7 +49,7 @@ function sri () {
           source = await (await fetch(resourcePath)).buffer();
         } else {
           // Load local source from bundle.
-          const resourcePathWithoutLeadingSlash = element.attribs[attributeName].slice(1);
+          const resourcePathWithoutLeadingSlash = resourcePath.slice(base.length);
           const bundleItem = bundle[resourcePathWithoutLeadingSlash];
           source = bundleItem.code || bundleItem.source;
         }

--- a/index.js
+++ b/index.js
@@ -24,10 +24,15 @@ import cheerio from 'cheerio'
 import fetch from 'node-fetch'
 
 export default function sri () {
+  let base = "/"
   return {
     name: 'vite-plugin-sri',
     enforce: 'post',
     apply: 'build',
+
+    async configResolved(config) {
+      base = config.base === "" ? "./" : config.base;
+    },
 
     async transformIndexHtml(html, context) {
       const bundle = context.bundle
@@ -41,7 +46,7 @@ export default function sri () {
           source = await (await fetch(resourcePath)).buffer()
         } else {
           // Load local source from bundle.
-          const resourcePathWithoutLeadingSlash = element.attribs[attributeName].slice(1)
+          const resourcePathWithoutLeadingSlash = resourcePath.slice(base.length)
           const bundleItem = bundle[resourcePathWithoutLeadingSlash]
           source = bundleItem.code || bundleItem.source
         }


### PR DESCRIPTION
Closes #11

The name is actually prefixed not with a slash, but with the config base. This PR takes that into account.
